### PR TITLE
Correct package.json main path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-logger",
   "version": "1.1.0",
   "description": "> Enhance $log for better logging, including patterns and level management",
-  "main": "angular-logger.min.js",
+  "main": "dist/angular-logger.min.js",
   "scripts": {
     "test": "gulp test"
   },


### PR DESCRIPTION
It looks like angular-logger.min.js was moved to the dist folder however package.json is still pointing at the old location. As a result, attempting to resolve the module directory using require in node fails because it cannot find the module file (specified by main).

This PR changes the path to point to the correct file location (inside dist).
