### PR TITLE
Now enhancing angular log before writing any log functions

### DIFF
--- a/src/angular-logger.js
+++ b/src/angular-logger.js
@@ -87,13 +87,13 @@ var angular = window.angular;
 	}]).
 	
     run(['$log', 'logEnhancer', function ($log, logEnhancer) {
+        logEnhancer.enhanceAngularLog($log);
         if (!sprintf) {
             $log.warn('sprintf.js not found: https://github.com/alexei/sprintf.js, using fixed layout pattern "%s::[%s]> "');
         }
         if (!moment) {
             $log.warn('moment.js not found: http://momentjs.com, using non-localized simple Date format');
         }
-        logEnhancer.enhanceAngularLog($log);
 		$log.info('logging enhancer initiated');
     }]);
 }(new LoggingEnhancer(sprintf, moment), angular, sprintf, moment));


### PR DESCRIPTION
I noticed a problem in my app that was caused by the fact that the log messages generated by missing sprintf and/or moment happened before the call to `logEnhancer.enhanceAngularLog($log)`.

Simply moving the call to enhanceAngularLog above the checks fixed it right up.
